### PR TITLE
Removed unused parameter

### DIFF
--- a/src/ErrorLogTarget.php
+++ b/src/ErrorLogTarget.php
@@ -77,7 +77,7 @@ class ErrorLogTarget extends Target
     /**
      * {{@inheritdoc}}
      */
-    protected function getContextMessage($message)
+    protected function getContextMessage()
     {
         // we don't want a context message to be appended, so we just return
         // an empty string

--- a/src/views/view.php
+++ b/src/views/view.php
@@ -80,7 +80,7 @@ $this->params['breadcrumbs'][] = $model->__toString();
                     'format' => 'raw',
                     'contentOptions' => ['class' => 'text-center'],
                     'value' => function ($m) {
-                        return Html::tag('span', '', [
+                        return Html::tag('span', $m->output, [
                             'class' => $m->error == 0 ? 'text-success glyphicon glyphicon-ok-circle' : 'text-danger glyphicon glyphicon-remove-circle'
                         ]);
                     }


### PR DESCRIPTION
Cause of warning if migrations are executed, the migrations failed with the message:

`PHP Warning 'yii\base\ErrorException' with message 'Declaration of thamtech\scheduler\ErrorLogTarget::getContextMessage($message) should be
compatible with yii\log\Target::getContextMessage()'`

`$message` is not really used cause function returns empty anyway.