### PR TITLE
Clarify mutex documentation with an explicitly defined example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ below:
         'scheduler' => [
             'class' => 'thamtech\scheduler\Module',
             
-            // optional: use the 'mutex' application component to acquire a lock
+            // optional: define a mutex component to acquire a lock
             // while executing tasks so only one execution of schedule tasks
             // can be running at a time.
-            'mutex' => 'mutex', 
+            'mutex' => [
+                'class' => 'yii\mutex\MysqlMutex',
+            ], 
+            
+            // OR optionally reference an existing application mutex component,
+            // for example, one named "mutex":
+            // 'mutex' => 'mutex',
         ],
     ],
     'components' => [


### PR DESCRIPTION
Make the default example mutex definition be an explicitly defined
component, `yii\mutex\MysqlMutex` in this case.

We also preserve as a separate example a case where you might reference
an existing application-defined mutex component by name.

Fixes #1